### PR TITLE
Remove java 8 from CI workflow and fix typos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ 8, 11, 16, 17 ]
+        java_version: [ 11, 16, 17 ]
         os: [windows-latest, macOS-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,28 +1,28 @@
 # Contributing
-Contributions of all types are welcome.   
+Contributions of all types are welcome.
 Please follow the [code of conduct][1] in all your interactions with this project.
 
 ## Asking Questions
-Please check the [README][2] and the [wiki][3] if you have a question.  
+Please check the [README][2] if you have a question.
 If you can't find an answer, please open an issue.
 
 ## Reporting Bugs
-Bugs can be reported by opening an issue.  
+Bugs can be reported by opening an issue.
 Please provide as much information as possible. Ideally, that would include a small sample project that reproduces the problem.
 
 ## Fixing Bugs, Adding Enhancements, Features and Documentation
-Code and documentation can be contributed by replying to an open issue to get it assigned to you, or by creating a new issue.  
-**Please make sure you get a response from one of the maintainers before you start working.**  
-You can find instructions on building the project in [README.md][2].  
-The code style is defined in Intellij project files in the repo and also by the provided Checkstyle config.  
+Code and documentation can be contributed by replying to an open issue to get it assigned to you, or by creating a new issue.
+**Please make sure you get a response from one of the maintainers before you start working.**
+You can find instructions on building the project in [README][2].
+The code style is defined in Intellij project files in the repo and also by the provided Checkstyle config.
 *If you can't get the style checks to pass, feel free to put up your pull request anyway and project maintainers can help you fix the style issues.*
 
 ## Issue Labels
-Issue labels will be assigned by the project maintainers.  
+Issue labels will be assigned by the project maintainers.
 Here are the current labels:
 
 * **bug**: Something isn't working
-* **dependecies**: Pull requests that update a dependency file
+* **dependencies**: Pull requests that update a dependency file
 * **duplicate**: This issue or pull request already exists
 * **feature**: New behavior or a tweak/addition to existing behavior
 * **good first issue**: Good for newcomers
@@ -34,7 +34,6 @@ Here are the current labels:
 * **reproducible**: Can easily reproduce, meaning enough information was provided
 * **stale**: Stale issues will be closed automatically
 * **wontfix**: Working as intended, or won't be fixed due to compatibility or other reasons
- 
+
 [1]: https://github.com/yevgenykuz/java-gradle-starter/blob/master/CODE_OF_CONDUCT.md
 [2]: https://github.com/yevgenykuz/java-gradle-starter/blob/master/README.rst
-[3]: https://github.com/yevgenykuz/java-gradle-starter/wiki


### PR DESCRIPTION
## Summary
Remove java 8 from CI workflow and fix typos.